### PR TITLE
Use Dir#entries, since Dir.glob does not return error on Permission Deni...

### DIFF
--- a/lib/openvpn_cert_nagios/base.rb
+++ b/lib/openvpn_cert_nagios/base.rb
@@ -1,5 +1,6 @@
 require "nagios_check"
 require 'open3'
+require 'date'
 
 require "openvpn_cert_nagios/version"
 require "openvpn_cert_nagios/shell"

--- a/lib/openvpn_cert_nagios/check.rb
+++ b/lib/openvpn_cert_nagios/check.rb
@@ -22,7 +22,7 @@ class CertCheck
   end
 
   def certs
-    @certs ||= Dir.glob("#{ options.path }/*.crt")
+    @certs ||= Dir.new(options.path).entries.find_all{ |f| f =~ /.*\.crt$/ }.map { |f| "#{ options.path }/#{ f }" }
   end
 
 end

--- a/lib/openvpn_cert_nagios/check.rb
+++ b/lib/openvpn_cert_nagios/check.rb
@@ -22,7 +22,10 @@ class CertCheck
   end
 
   def certs
-    @certs ||= Dir.new(options.path).entries.find_all{ |f| f =~ /.*\.crt$/ }.map { |f| "#{ options.path }/#{ f }" }
+    @certs ||= Dir.new(options.path)
+      .entries
+      .find_all{ |f| f =~ /.*\.crt$/ }
+      .map { |f| "#{ options.path }/#{ f }" }
   end
 
 end

--- a/lib/openvpn_cert_nagios/version.rb
+++ b/lib/openvpn_cert_nagios/version.rb
@@ -1,3 +1,3 @@
 class CertCheck
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
...ed.

`Dir.glob` does look nicer, but on directory without read permissions (Permission denied) returns empty Array `[]` without error. Not what I really want. 